### PR TITLE
Make the default chart display period configurable

### DIFF
--- a/skwissh/templates/section-graph.html
+++ b/skwissh/templates/section-graph.html
@@ -3,12 +3,12 @@
 	<ul class="nav-bar">
 		<li><a class="bigger" href="#section-{{ probe.id }}">{{ probe.display_name }}</a></li>
 		{% ifnotequal probe.graph_type.name 'text' %}
-		<li><a class='period period-{{ probe.id }}' data-period='last' href="#">{% trans 'Dernière mesure' %}</a></li>
-		<li class="active"><a class='period period-{{ probe.id }}' data-period='hour' href="#">{% trans 'Dernière heure' %}</a></li>
-		<li><a class='period period-{{ probe.id }}' data-period='day' href="#">{% trans 'Dernière journée' %}</a></li>
-		<li><a class='period period-{{ probe.id }}' data-period='week' href="#">{% trans 'Dernière semaine' %}</a></li>
-		<li><a class='period period-{{ probe.id }}' data-period='month' href="#">{% trans 'Dernier mois' %}</a></li>
-		{% endifnotequal %}	
+		<li{% if default_view == "last" %} class="active"{% endif %}><a class='period period-{{ probe.id }}' data-period='last' href="#">{% trans 'Dernière mesure' %}</a></li>
+		<li{% if default_view == "hour" %} class="active"{% endif %}><a class='period period-{{ probe.id }}' data-period='hour' href="#">{% trans 'Dernière heure' %}</a></li>
+		<li{% if default_view == "day" %} class="active"{% endif %}><a class='period period-{{ probe.id }}' data-period='day' href="#">{% trans 'Dernière journée' %}</a></li>
+		<li{% if default_view == "week" %} class="active"{% endif %}><a class='period period-{{ probe.id }}' data-period='week' href="#">{% trans 'Dernière semaine' %}</a></li>
+		<li{% if default_view == "month" %} class="active"{% endif %}><a class='period period-{{ probe.id }}' data-period='month' href="#">{% trans 'Dernier mois' %}</a></li>
+		{% endifnotequal %}
 	</ul>
 	<div class="panel graph">
 		{% ifnotequal probe.graph_type.name 'text' %}
@@ -29,11 +29,11 @@
 	    				<li>{{ graphtype.name }}</li>
 	    				{% endfor %}
 	  				</ul>
-				</div>				
+				</div>
 			</form>
 		</div>
 		<a class='right download' href="#" onclick="javascript: window.open(jqplotToImg($('#graph-{{ probe.id }}')))">{% trans 'Télécharger le graphique...' %}</a>
-		{% endifnotequal %}	
+		{% endifnotequal %}
 		<div id="detail-{{ probe.id }}">
 			<p class="waiting-title">{% trans 'Chargement des données en cours...' %}<p>
 			<div class="waiting"></div>

--- a/skwissh/templates/skwissh_graphs.js
+++ b/skwissh/templates/skwissh_graphs.js
@@ -20,7 +20,7 @@ $(document).ready(function() {
 	$.jqplot.config.enablePlugins = true; 	
 	{% for probe in server.probes.all %}
 	var graphtype = '{{ probe.graph_type.name }}';
-	refreshGraph(get_mesures_url.replace('period', 'hour').replace('999', {{ probe.id }}), 'hour', graphtype, {{ probe.id }}, '{{ probe.display_name }}', '{{ probe.probe_labels }}', '{{ probe.probe_unit }}');
+	refreshGraph(get_mesures_url.replace('period', '{{default_view}}').replace('999', {{ probe.id }}), '{{default_view}}', graphtype, {{ probe.id }}, '{{ probe.display_name }}', '{{ probe.probe_labels }}', '{{ probe.probe_unit }}');
 	{% endfor %}
 });
 {% for probe in server.probes.all %}{% ifnotequal probe.graph_type.name 'text' %}

--- a/skwissh/views.py
+++ b/skwissh/views.py
@@ -50,7 +50,8 @@ def server_detail(request, server_id):
             'server_form': form,
             'server': server,
             'groups': ServerGroup.objects.all().order_by('name'),
-            'nogroup_servers': Server.objects.filter(servergroup__isnull=True).order_by('hostname')
+            'nogroup_servers': Server.objects.filter(servergroup__isnull=True).order_by('hostname'),
+            'default_view': getattr(settings, "SKWISSH_DEFAULT_VIEW", 'hour') in ('last', 'hour', 'day', 'week', 'month') and getattr(settings, "SKWISSH_DEFAULT_VIEW", 'hour') or 'hour'
     }
     return render(request, 'server-detail.html', data)
 


### PR DESCRIPTION
Still defaults to "hour", but by setting SKWISSH_DEFAULT_VIEW to either of "last", "hour", "day", "week",  "month" sets the default display interval.
